### PR TITLE
A inverse value for branch and bus info

### DIFF
--- a/tensorpowerflow/grid.py
+++ b/tensorpowerflow/grid.py
@@ -35,6 +35,7 @@ class GridTensor:
         self.tolerance = tolerance
 
         if node_file_path is None and lines_file_path is None:
+            # here node frame and line frame are given to the inverse value
             _nodes_frame, _lines_frame = _load_default_34_node_case()
             self.branch_info = _nodes_frame
             self.bus_info = _lines_frame

--- a/tensorpowerflow/utils.py
+++ b/tensorpowerflow/utils.py
@@ -11,6 +11,7 @@ except ModuleNotFoundError:
     pass
 
 def _load_default_34_node_case():
+
     stream_node_data = pkg_resources.resource_stream(__name__, "data/Lines_34.csv")
     stream_line_data = pkg_resources.resource_stream(__name__, "data/Nodes_34.csv")
 


### PR DESCRIPTION
In grid.py, code line:37.
_node_frame and _lines_frames are given the value inversed their name. I guess that's why self.branch_info=_node_frame and self.bus_info=_lines_frame