### PR TITLE
Fix the handling of arguments in the constructor of GridTensor

### DIFF
--- a/tensorpowerflow/grid.py
+++ b/tensorpowerflow/grid.py
@@ -55,7 +55,8 @@ class GridTensor:
         self.iterations = iterations
         self.tolerance = tolerance
 
-        if node_file_path is None and lines_file_path is None:
+        if (node_file_path is None and lines_file_path is None
+                and nodes_frame is None and lines_frame is None):
             # here node frame and line frame are given to the inverse value
             _nodes_frame, _lines_frame = _load_default_34_node_case()
             self.branch_info = _nodes_frame


### PR DESCRIPTION
With the current logic, the following call to the constructor of `GridTensor` does not achieve what it should:
```python
GridTensor(nodes_frame=nodes_df, lines_frame=lines_df)
```

The reason is that if the keywords `node_file_path` and `lines_file_path` are both null, then the default grid is used, instead of using the dataframes passed as arguments.

This PR fixes the problem with one line of code.